### PR TITLE
Add include list to plugin configuration options

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
 		"ms-python.python",
 		"redhat.vscode-yaml",
 		"streetsidesoftware.code-spell-checker",
-		"yzhang.markdown-all-in-one"
+		"yzhang.markdown-all-in-one",
+		"shakram02.bash-beautify"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
@@ -43,7 +44,7 @@
 		"source=/${env:HOME}/.bash_aliases,target=/home/vscode/.bash_aliases,type=bind,consistency=cached"
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+	"postCreateCommand": "pip3 install --user -r requirements.txt",
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "elgohr",
     "emoji",
     "entrypoint",
+    "fnmatch",
     "generator",
     "github",
     "heinrichreimer",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install mkdocs-simple-plugin
 
 _Python 3.x, 3.5, 3.6, 3.7, 3.8 supported._
 
-### Build your docs
+### Build the docs
 
 It's easy to use this plugin.  You can either use the generation script included, or set up your own custom config.
 
@@ -82,17 +82,7 @@ One of the best parts of mkdocs is it's ability to serve (and update!) your docu
 mkdocs serve
 ```
 
-### Deploy to gh-pages
-
-After you build, you'll need to initialize your deployment by running the gh-deploy command for mkdocs.  This will set up the gh-pages branch and copy the site over.
-
-```bash
-mkdocs gh-deploy
-```
-
-Then you'll need to set up your github repository to enable gh-pages support. See [Github Pages](https://pages.github.com/) for more information.
-
-## Docker
+## Run in a docker container
 
 Additionally, you can use this plugin with the [athackst/mkdocs-simple-plugin](https://hub.docker.com/r/athackst/mkdocs-simple-plugin) docker image.
 
@@ -131,7 +121,60 @@ See [mkdocs_simple_gen](mkdocs_simple_plugin/README.md#mkdocs_simple_gen) for a 
     ```
 <!-- markdownlint-enable MD046 -->
 
-## Build from source
+## Deploy
+
+### Enable GitHub pages
+
+First, set up your github repository to enable gh-pages support.
+
+See [Github Pages](https://pages.github.com/) for more information.
+
+### Deploy from the command line
+
+Mkdocs includes an easy command to initialize your deployment from the command line. This will set up the gh-pages branch and copy the site over.
+
+```bash
+mkdocs gh-deploy
+```
+
+Then push the results to your repository (or wherever you'd like to host your site).
+
+### Deploy from GitHub Actions
+
+Create a yaml file with the following contents in the `.github/workflows` directory in your repository
+
+```yaml
+name: Docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Build Docs
+        run: |
+          mkdocs_simple_gen
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+```
+
+## Build plugin from source
 
 ### Prerequisites
 
@@ -174,8 +217,6 @@ If you want to test against all the different versions of python, run the local 
 ```bash
 ./tests/test_local.sh
 ```
-
-<!--TODO github integration -->
 
 ## License
 

--- a/mkdocs_simple_plugin/README.md
+++ b/mkdocs_simple_plugin/README.md
@@ -16,8 +16,10 @@ Create a `mkdocs.yml` file in the root of your directory and add this plugin to 
 site_name: your_site_name
 plugins:
   - simple:
+      # Optional setting to only include specific folders
+      include_folders: ["*"]
       # Optional setting to ignore specific folders
-      ignore_folders: ["tests"]
+      ignore_folders: [""]
       # Optional setting to specify if hidden folders should be ignored
       ignore_hidden: True
 ```

--- a/tests/integration/test.bats
+++ b/tests/integration/test.bats
@@ -52,6 +52,7 @@ assertGenEmpty() {
 
 assertServeSuccess() {
   run pgrep -x mkdocs
+  debugger
   [ ! -z "$status" ]
 }
 

--- a/tests/test_local.sh
+++ b/tests/test_local.sh
@@ -2,7 +2,7 @@
 
 set -e
 # Lint via flake8
-echo "Running flake8 linter -------->"
+echo "Running test_flake8  -------->"
 ./tests/test_flake8.sh
 
 # End-to-end testing via Bats (Bash automated tests)
@@ -22,11 +22,11 @@ docker run --rm -it -w /workspace mkdocs-simple-test-runner:$1
 }
 
 if [[ ! -z "$PYTHON_37_ONLY" ]]; then
-  docker_run_integration_tests "3.7-slim"
+  docker_run_integration_tests "3.7"
 else
-  docker_run_integration_tests "3-slim"
-  docker_run_integration_tests "3.5-slim"
-  docker_run_integration_tests "3.6-slim"
-  docker_run_integration_tests "3.7-slim"
-  docker_run_integration_tests "3.8-slim"
+  docker_run_integration_tests "3"
+  docker_run_integration_tests "3.5"
+  docker_run_integration_tests "3.6"
+  docker_run_integration_tests "3.7"
+  docker_run_integration_tests "3.8"
 fi


### PR DESCRIPTION
Adds the ability to specify folders for inclusion into your mkdocs site.  Folder names follow standard unix file wildcards, provided by [fnmatch](https://docs.python.org/3/library/fnmatch.html).