### PR TITLE
Add support for include_extensions flag to support images

### DIFF
--- a/mkdocs_simple_plugin/README.md
+++ b/mkdocs_simple_plugin/README.md
@@ -23,7 +23,7 @@ plugins:
       # Optional setting to specify if hidden folders should be ignored
       ignore_hidden: True
       # Optional setting to specify other extensions besides md files to be copied
-      include_extensions: [".md"]
+      include_extensions: [""]
 ```
 
 ## mkdocs_simple_gen

--- a/mkdocs_simple_plugin/README.md
+++ b/mkdocs_simple_plugin/README.md
@@ -22,6 +22,8 @@ plugins:
       ignore_folders: [""]
       # Optional setting to specify if hidden folders should be ignored
       ignore_hidden: True
+      # Optional setting to specify other extensions besides md files to be copied
+      include_extensions: [".md"]
 ```
 
 ## mkdocs_simple_gen

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -15,7 +15,8 @@ class SimplePlugin(BasePlugin):
     config_scheme = (
         ('include_folders', config_options.Type(list, default=['*'])),
         ('ignore_folders', config_options.Type(list, default=[])),
-        ('ignore_hidden', config_options.Type(bool, default=True))
+        ('ignore_hidden', config_options.Type(bool, default=True)),
+        ('include_extensions', config_options.Type(list, default=['.md']))
     )
 
     def __init__(self):
@@ -28,6 +29,7 @@ class SimplePlugin(BasePlugin):
                                 config['site_dir'],
                                 self.docs_dir]
         self.ignore_hidden = self.config['ignore_hidden']
+        self.include_extensions = self.config['include_extensions']
         # Update the docs_dir with our temporary one!
         self.orig_docs_dir = config['docs_dir']
         config['docs_dir'] = self.docs_dir
@@ -72,17 +74,18 @@ class SimplePlugin(BasePlugin):
         for root, dirs, files in os.walk("."):
             if self.include_dir(root):
                 for f in files:
-                    if ".md" in f:
-                        doc_root = "./" + self.docs_dir + root[1:]
-                        orig = "{}/{}".format(root, f)
-                        new = "{}/{}".format(doc_root, f)
-                        try:
-                            os.makedirs(doc_root, exist_ok=True)
-                            shutil.copy(orig, new)
-                            print("{} --> {}".format(orig, new))
-                            paths.append((orig, new))
-                        except Exception as e:
-                            print("ERROR: {}.. skipping {}".format(e, orig))
+                    for extension in self.include_extensions:
+                        if extension in f:
+                            doc_root = "./" + self.docs_dir + root[1:]
+                            orig = "{}/{}".format(root, f)
+                            new = "{}/{}".format(doc_root, f)
+                            try:
+                                os.makedirs(doc_root, exist_ok=True)
+                                shutil.copy(orig, new)
+                                print("{} --> {}".format(orig, new))
+                                paths.append((orig, new))
+                            except Exception as e:
+                                print("ERROR: {}.. skipping {}".format(e, orig))
 
             dirs[:] = [d for d in dirs if self.search_dir(d)]
         return paths

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -74,8 +74,7 @@ class SimplePlugin(BasePlugin):
         for root, dirs, files in os.walk("."):
             if self.include_dir(root):
                 for f in files:
-                    for extension in self.include_extensions:
-                        if extension in f:
+                   if any(extension in f for extension in self.include_extensions):
                             doc_root = "./" + self.docs_dir + root[1:]
                             orig = "{}/{}".format(root, f)
                             new = "{}/{}".format(doc_root, f)

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -29,7 +29,7 @@ class SimplePlugin(BasePlugin):
                                 config['site_dir'],
                                 self.docs_dir]
         self.ignore_hidden = self.config['ignore_hidden']
-        self.include_extensions = self.config['include_extensions']
+        self.include_extensions = ['.md'] + self.config['include_extensions']
         # Update the docs_dir with our temporary one!
         self.orig_docs_dir = config['docs_dir']
         config['docs_dir'] = self.docs_dir

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -16,7 +16,7 @@ class SimplePlugin(BasePlugin):
         ('include_folders', config_options.Type(list, default=['*'])),
         ('ignore_folders', config_options.Type(list, default=[])),
         ('ignore_hidden', config_options.Type(bool, default=True)),
-        ('include_extensions', config_options.Type(list, default=['.md']))
+        ('include_extensions', config_options.Type(list, default=[]))
     )
 
     def __init__(self):

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -74,17 +74,17 @@ class SimplePlugin(BasePlugin):
         for root, dirs, files in os.walk("."):
             if self.include_dir(root):
                 for f in files:
-                   if any(extension in f for extension in self.include_extensions):
-                            doc_root = "./" + self.docs_dir + root[1:]
-                            orig = "{}/{}".format(root, f)
-                            new = "{}/{}".format(doc_root, f)
-                            try:
-                                os.makedirs(doc_root, exist_ok=True)
-                                shutil.copy(orig, new)
-                                print("{} --> {}".format(orig, new))
-                                paths.append((orig, new))
-                            except Exception as e:
-                                print("ERROR: {}.. skipping {}".format(e, orig))
+                    if any(extension in f for extension in self.include_extensions):
+                        doc_root = "./" + self.docs_dir + root[1:]
+                        orig = "{}/{}".format(root, f)
+                        new = "{}/{}".format(doc_root, f)
+                        try:
+                            os.makedirs(doc_root, exist_ok=True)
+                            shutil.copy(orig, new)
+                            print("{} --> {}".format(orig, new))
+                            paths.append((orig, new))
+                        except Exception as e:
+                            print("ERROR: {}.. skipping {}".format(e, orig))
 
             dirs[:] = [d for d in dirs if self.search_dir(d)]
         return paths


### PR DESCRIPTION
This adds support for other file extensions, allowing the user to provide images and other files that are included in the markdown.