### PR TITLE
feat: Allow semiliterate patterns with multiple "modes" of extraction

### DIFF
--- a/examples/ok-mkdocs-docs-include/README.md
+++ b/examples/ok-mkdocs-docs-include/README.md
@@ -34,8 +34,10 @@ project
 |   |    index.md
 │
 └───site
-│   │   index.html
-|   |   
-|   └───draft
-│   │   |    index.html
+|   |
+|   └───subfolder
+│       │   index.html  [From subfolder/index.md, not from README.md]
+|       |
+|       └───draft
+│       │   |    index.html
 ```

--- a/examples/ok-mkdocs-docs-merge/README.md
+++ b/examples/ok-mkdocs-docs-merge/README.md
@@ -34,7 +34,7 @@ project
 |   |    index.md
 │
 └───site
-│   │   index.html
+│   │   index.html  [From docs/index.md, _not_ from README]
 |   |   
 |   └───draft
 │   │   |    index.html

--- a/examples/ok-mkdocs-docs-no-merge/README.md
+++ b/examples/ok-mkdocs-docs-no-merge/README.md
@@ -1,6 +1,6 @@
 # Don't merge docs folder with other docs
 
-This example shows how to keep the docs folder with your 
+This example shows how to keep the docs folder embedded within your other docs.
 
 ## Configuration
 
@@ -34,14 +34,14 @@ project
 |   |    index.md
 │
 └───site
-│   │   index.html
-|   |   
-|   └───draft
-│   │   |    index.html
+│   │   index.html  [From README.md]
 |   |   
 |   └───test
 │   │   |    index.html
-|   |  
-|   └───index
-│   │   |    index.html
+|   |
+|   └───docs
+│   │   |    index.html  [From docs/index.md]
+|   |   |
+|   |   └───draft
+│   │   |   |    index.html
 ```

--- a/examples/ok-with-macros/README.md
+++ b/examples/ok-with-macros/README.md
@@ -10,7 +10,7 @@ Here's a print out of the plugin's config file, which I've included using a jinj
 {% include "mkdocs.yml" %}
 ```
 
-And the extracted module documentation includes the readme.
+And the extracted module documentation also includes the config file.
 
 extracted:
 

--- a/examples/ok-with-mkdocstrings/README.md
+++ b/examples/ok-with-mkdocstrings/README.md
@@ -1,13 +1,14 @@
 # Use with mkdocstrings
 
-You can even use this with other plugins, like [mkdocstrings](https://pypi.org/project/mkdocstrings/) to achieve advanced configurations.
+You can even use this with other plugins, like [mkdocstrings](https://pypi.org/project/mkdocstrings/), to achieve advanced configurations.
 
 ## Example
 
 
-The extracted module documentation includes the documentation from the module header.
+The extracted [module documentation](module.md) includes the documentation from the module header, and has invoked mkdocstrings to render api documentation based on Python docstrings.
 
-Extracted:
+Compare the webpage linked above with the raw `module.md` generated
+by extraction from `module.py`:
 
 ```
 {% include "examples/ok-with-mkdocstrings/module.md" %}

--- a/examples/ok-with-mkdocstrings/module.grepout
+++ b/examples/ok-with-mkdocstrings/module.grepout
@@ -1,5 +1,5 @@
 <p>You can put <em>markdown</em> in triple-quoted strings in Python.</p>
 <p>You can even combine it with mkdocstrings to automatically generate your source documentation!</p>
-<p>This is a test function.  It takes no paramers.</p>
+<p>This is a test function.  It takes no parameters.</p>
 <p>It says "Hello, world!"</p>
             <p>Documentation built with <a href="https://www.mkdocs.org/">MkDocs</a>.</p>

--- a/examples/ok-with-mkdocstrings/module.py
+++ b/examples/ok-with-mkdocstrings/module.py
@@ -16,7 +16,7 @@ You can even combine it with mkdocstrings to automatically generate your source 
 
 def main():
     """
-    This is a test function.  It takes no paramers.
+    This is a test function.  It takes no parameters.
 
     It says "Hello, world!"
     """

--- a/examples/ok-with-rename/mkdocs-test.yml
+++ b/examples/ok-with-rename/mkdocs-test.yml
@@ -3,6 +3,5 @@ plugins:
       semiliterate:
       - pattern: '^foo.bar$'
         destination: baz.md
-        start: '^(.*\s*)$'
 
 site_name: ok-with-rename

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,12 @@ plugins:
         - ".yml"
         - ".png"
   - macros:
+  - mkdocstrings:
+      handlers:
+        python:
+          setup_commands:
+          - import sys
+          - sys.path.append('examples/ok-with-mkdocstrings')
   - awesome-pages:
       collapse_single_pages: true
 theme:


### PR DESCRIPTION
  Specifically, move the `start`, `stop`, and `replace` parameters into
  a new `extract` parameter, and allow multiple blocks of them. When one of the
  `start` regexps matches, it activates that group of the parameters, so it will
  only end with the corresponding `stop` parameter (other `stop` expressions
  will not be checked) and will only do its own replacements. So for example in
  Python, `# /md` will now only end a `# md` block, not a triple-quoted string,
  and leading `#` will not be stripped in triple-quoted strings.

  Adjust all of the existing documentation to use the new parameters.

  Corrects some typos and inaccuracies in existing documentation.

  Takes the liberty of adding to the ok-with-mkdocstrings example a comparison
  of the extracted module.md and the generated module/index.html, to better 
  highlight the inter-operation with the mkdocstrings module.

  Resolves #96.
