### PR TITLE
fix: Make extraction w/ no start pattern active from beginning

### DIFF
--- a/examples/.pages
+++ b/examples/.pages
@@ -3,12 +3,12 @@ nav:
     - Docs folder: examples/ok-mkdocs-docs/docs
     - Ignore a folder: examples/ok-mkdocs-docs-ignore
     - Extra extensions: examples/ok-mkdocs-docs-extensions
-    - Custom extraction: examples/ok-mkdocs-custom-extract
     - Only include a specific folder: examples/ok-mkdocs-docs-include
     - Merge into docs folder: examples/ok-mkdocs-docs-merge
     - Don't merge docs folder: examples/ok-mkdocs-docs-no-merge
     - Rename a file: examples/ok-with-rename
     - Extract docs from source: examples/ok-source-extract
+    - Custom extraction: examples/ok-mkdocs-custom-extract
     - Extract docs with macros: examples/ok-with-macros
     - Extract docs with mkdocstrings: examples/ok-with-mkdocstrings
     - Extract a snippet: examples/ok-source-with-snippet

--- a/examples/.pages
+++ b/examples/.pages
@@ -3,6 +3,7 @@ nav:
     - Docs folder: examples/ok-mkdocs-docs/docs
     - Ignore a folder: examples/ok-mkdocs-docs-ignore
     - Extra extensions: examples/ok-mkdocs-docs-extensions
+    - Custom extraction: examples/ok-mkdocs-custom-extract
     - Only include a specific folder: examples/ok-mkdocs-docs-include
     - Merge into docs folder: examples/ok-mkdocs-docs-merge
     - Don't merge docs folder: examples/ok-mkdocs-docs-no-merge

--- a/examples/ok-mkdocs-custom-extract/README.md
+++ b/examples/ok-mkdocs-custom-extract/README.md
@@ -1,0 +1,36 @@
+# Custom extraction
+
+This example shows how to set up custom extraction modes. Litcoffee files
+consist of interspersed Markdown and Coffeescript code. The pattern
+defined here extracts a documentation page from each such file, consisting of:
+everything from the beginning of the file to the first line of code
+(a line indented by at least four spaces), together with any later Markdown
+block preceded by a comment containing `# DOCPAGE`.
+
+## mkdocs.yml
+
+```yaml
+{% include "examples/ok-mkdocs-custom-extract/mkdocs-test.yml" %}
+```
+
+## Input
+
+```
+project
+│   README.md
+│   fibo.litcoffee 
+```
+
+## Output
+
+```
+project
+│   README.md
+│   fibo.litcoffee 
+│
+└───site
+│   │   index.html
+|   |   
+|   └───fibo
+│   │   |    index.html
+```

--- a/examples/ok-mkdocs-custom-extract/fibo.grepout
+++ b/examples/ok-mkdocs-custom-extract/fibo.grepout
@@ -1,0 +1,4 @@
+<p>This paragraph is here to make sure the extraction starts immediately.</p>
+<p>Although trite, this is an example of the sum recurrence.</p>
+<p>This note about complexity will appear in the doc page.</p></div>
+            <p>Documentation built with <a href="https://www.mkdocs.org/">MkDocs</a>.</p>

--- a/examples/ok-mkdocs-custom-extract/fibo.litcoffee
+++ b/examples/ok-mkdocs-custom-extract/fibo.litcoffee
@@ -1,0 +1,21 @@
+This paragraph is here to make sure the extraction starts immediately.
+# Coffee Fibonacci
+
+Although trite, this is an example of the sum recurrence.
+
+    fib = (n) ->
+      # Base cases
+      if n in [ 1 , 2 ]
+        return 1
+      # Recursive calls
+      fib(n-1) + fib(n-2)
+
+## Example usage
+This is perfectly good Markdown commentary, but will not appear in the
+extracted doc page.
+
+    fib(3) # => fib(2) + fib(1) => 2
+
+    # DOCPAGE
+## Complexity
+This note about complexity will appear in the doc page.

--- a/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
+++ b/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
@@ -1,0 +1,8 @@
+site_name: Custom Extraction
+plugins:
+  - simple:
+      semiliterate:
+        - pattern: '\.litcoffee'
+          extract:
+            - {stop: '^\s{4,}\S'}  # No start, so active from beginning
+            - {start: '# DOCPAGE', stop: '^\s{4,}\S'}

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -174,7 +174,7 @@ class SimplePlugin(BasePlugin):
         # Example:
         #
         # `````
-        # ```<md file=ouput_path.md>
+        # # md file=ouput_path.md
         # `````
         #
         #
@@ -242,7 +242,7 @@ class SimplePlugin(BasePlugin):
                                 'stop': r'^\s*#\s?\/md\s*$',
                                 # strip leading spaces and `#``
                                 'replace': [r'^\s*# ?(.*\n?)$'],
-                                #                              
+                                #
                                 # ```python
                                 # # md
                                 # # This is a documentation comment.
@@ -275,7 +275,7 @@ class SimplePlugin(BasePlugin):
                                 'stop': r'^\s*\/\/\send\smd\s*$',
                                 # strip leading spaces and `//`
                                 'replace': [r'^\s*\/\/\s?(.*\n?)$'],
-                                #                              
+                                #
                                 # ```c
                                 # // md
                                 # // This is a documentation comment.
@@ -296,7 +296,7 @@ class SimplePlugin(BasePlugin):
                             'stop': r'#\s\/md\s*$',
                             # strip leading spaces and `#`
                             'replace': [r'^\s*#?\s?(.*\n?)$'],
-                            # 
+                            #
                             # ```yaml
                             # # md
                             # # This is a documentation comment.
@@ -313,9 +313,9 @@ class SimplePlugin(BasePlugin):
                             # `<!-- md` and ending with `-->`
                             'start': r'<!--\W?md\b',
                             'stop': r'-->\s*$',
-                            # 
+                            #
                             # ```xml
-                            # <!-- md 
+                            # <!-- md
                             # This is a documentation comment.
                             # -->
                             # ```

--- a/mkdocs_simple_plugin/semiliterate.py
+++ b/mkdocs_simple_plugin/semiliterate.py
@@ -119,6 +119,10 @@ class StreamExtract:
         any text is actually extracted, false otherwise.
         """
         active_pattern = None if self.patterns else ExtractionPattern()
+        for pattern in self.patterns:
+            if not pattern.start:
+                active_pattern = pattern
+
         for line in self.input_stream:
             # Check terminate, regardless of state:
             if self.check_pattern(self.terminate, line, active_pattern):
@@ -126,8 +130,7 @@ class StreamExtract:
             # Change state if flagged to do so:
             if active_pattern is None:
                 for pattern in self.patterns:
-                    if not pattern.start or self.check_pattern(
-                            pattern.start, line):
+                    if self.check_pattern(pattern.start, line):
                         active_pattern = pattern
                         self.set_output_stream(line)
                         break

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -164,6 +164,14 @@ teardown() {
     assertFileExists site/test.txt
 }
 
+@test "use custom extraction parameters" {
+    cd ${fixturesDir}/ok-mkdocs-custom-extract
+    assertGen
+    assertValidSite
+    assertFileExists site/fibo/index.html
+    assertParGrep fibo
+}
+
 @test "ignore site directory" {
     cd ${fixturesDir}/ok-mkdocs-ignore-site-dir
     assertGen


### PR DESCRIPTION
   This commit restores the behavior as documented that an extraction with
   no start pattern is active from the first line of the file, and cannot
   be reactivated once it ends.

   Adds a test for the behavior of such custom extraction specifications.

   Also updates the example of specifying an output path for extracted
   content, as the prior example does not correspond to any of the
   standard syntaxes listed for initiating markdown extraction, and so
   might be confusing.

   Resolves #137.