### PR TITLE
correct site names in examples to use folder name

### DIFF
--- a/examples/ok-mkdocs-config/mkdocs-test.yml
+++ b/examples/ok-mkdocs-config/mkdocs-test.yml
@@ -1,3 +1,3 @@
+site_name: ok-mkdocs-config
 plugins:
 - simple
-site_name: ok-mkdocs-config

--- a/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
+++ b/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
@@ -4,7 +4,7 @@
 # everything from the beginning of the file to the first line of code
 # (a line indented by at least four spaces), together with any later Markdown
 # block preceded by a comment containing `# DOCPAGE`.
-site_name: Custom Extraction
+site_name: ok-mkdocs-custom-extract
 plugins:
   - simple:
       semiliterate:

--- a/examples/ok-mkdocs-docs-extensions/mkdocs-test.yml
+++ b/examples/ok-mkdocs-docs-extensions/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how extensions are copied to the result
-site_name: project
+site_name: ok-mkdocs-docs-extensions
 plugins:
   - simple:
       include_extensions: [".txt"]

--- a/examples/ok-mkdocs-docs-ignore/mkdocs-test.yml
+++ b/examples/ok-mkdocs-docs-ignore/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how a subfolder can be ignored.
-site_name: project
+site_name: ok-mkdocs-docs-ignore
 plugins:
   - simple:
       ignore_folders: ["subfolder"]

--- a/examples/ok-mkdocs-docs-include/mkdocs-test.yml
+++ b/examples/ok-mkdocs-docs-include/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how to only include from a specific folder
-site_name: project
+site_name: ok-mkdocs-docs-include
 plugins:
   - simple:
       include_folders: ["./subfolder**"]

--- a/examples/ok-mkdocs-docs-merge/mkdocs-test.yml
+++ b/examples/ok-mkdocs-docs-merge/mkdocs-test.yml
@@ -1,4 +1,4 @@
 # This example shows how to merge a docs folder with other documentation.
-site_name: project
+site_name: ok-mkdocs-docs-merge
 plugins:
   - simple

--- a/examples/ok-mkdocs-docs-no-merge/mkdocs-test.yml
+++ b/examples/ok-mkdocs-docs-no-merge/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how to keep the docs folder embedded within your other docs.
-site_name: project
+site_name: ok-mkdocs-docs-no-merge
 plugins:
   - simple:
         merge_docs_dir: false

--- a/examples/ok-mkdocs-ignore-site-dir/mkdocs-test.yml
+++ b/examples/ok-mkdocs-ignore-site-dir/mkdocs-test.yml
@@ -1,4 +1,4 @@
 # This tests if the site directory is ignored in both build and serve.
-site_name: ok-mkdocs-docs-ignore-site-dir
+site_name: ok-mkdocs-ignore-site-dir
 plugins:
 - simple:

--- a/examples/ok-mkdocs-readme/mkdocs-test.yml
+++ b/examples/ok-mkdocs-readme/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This is the simplest documentation site you could have.  
 # It's just a simple readme.
-site_name: project
+site_name: ok-mkdocs-readme
 plugins:
   - simple

--- a/examples/ok-source-extract/mkdocs-test.yml
+++ b/examples/ok-source-extract/mkdocs-test.yml
@@ -1,4 +1,4 @@
 # This examples shows how you can extract markdown from a source file.
-site_name: project
+site_name: ok-source-extract
 plugins:
   - simple

--- a/examples/ok-source-replace/mkdocs-test.yml
+++ b/examples/ok-source-replace/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how to replace lines with regex expressions!
-site_name: project
+site_name: ok-source-replace
 plugins:
   - simple:
       semiliterate:

--- a/examples/ok-source-with-snippet/mkdocs-test.yml
+++ b/examples/ok-source-with-snippet/mkdocs-test.yml
@@ -1,6 +1,6 @@
 # This is example shows to to create a snippet from a file.  For example, you 
 # can use a snippet to rerrange contents using inclusion or create a new pages 
 # per module.
-site_name: project
+site_name: ok-source-with-snippet
 plugins:
   - simple

--- a/examples/ok-with-macros/mkdocs-test.yml
+++ b/examples/ok-with-macros/mkdocs-test.yml
@@ -1,7 +1,7 @@
 # You can even use this with other plugins, like 
 # [macros](https://pypi.org/project/mkdocs-macros-plugin/) to achieve advanced 
 # configurations.
-site_name: project
+site_name: ok-with-macros
 docs_dir: /tmp/mkdocs-simple/ok-with-macros/docs
 plugins:
     - search

--- a/examples/ok-with-macros/module.grepout
+++ b/examples/ok-with-macros/module.grepout
@@ -2,7 +2,7 @@
 <p>You can put <em>markdown</em> in triple-quoted strings in Python.</p>
 <p>You can even use macros to inject other markdown here!</p>
 <p>For example, here's the config file:</p>
-<pre><code class="language-yaml">site_name: project
+<pre><code class="language-yaml">site_name: ok-with-macros
 docs_dir: /tmp/mkdocs-simple/ok-with-macros/docs
 plugins:
   - search

--- a/examples/ok-with-mkdocstrings/mkdocs-test.yml
+++ b/examples/ok-with-mkdocstrings/mkdocs-test.yml
@@ -1,7 +1,7 @@
 # You can even use this with other plugins, like 
 # [mkdocstrings](https://pypi.org/project/mkdocstrings/), to achieve advanced 
 # configurations.
-site_name: project
+site_name: ok-with-mkdocstrings
 plugins:
   - simple
   - mkdocstrings

--- a/examples/ok-with-rename/mkdocs-test.yml
+++ b/examples/ok-with-rename/mkdocs-test.yml
@@ -1,5 +1,5 @@
 # This example shows how to rename a single file in the doc site.
-site_name: project
+site_name: ok-with-rename
 plugins:
   - simple:
       semiliterate:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,6 +39,7 @@ assertGen() {
         cp mkdocs-test.yml mkdocs.yml
     fi
     run mkdocs_simple_gen
+    check_site_name
     run mkdocs build --verbose
     debugger
     [ "$status" -eq 0 ]
@@ -83,6 +84,13 @@ assertParGrep() {
     cat site/$1.grepout
     echo "--------------"
     [ "$status" -eq 0 ]
+}
+
+check_site_name() {
+    site_name=$(cat mkdocs.yml | sed -n 's/site_name: \(.*\)/\1/p')
+    directory_name=${PWD##*/}
+    echo "mkdocs site_name: $site_name, directory: $directory_name"
+    [ "$site_name" == "$directory_name" ]
 }
 
 ##


### PR DESCRIPTION
By enforcing the site name to the folder, it will enable users to locate the appropriate example in code.