### PR TITLE
remove bandaid on mkdocstrings 

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -67,8 +67,6 @@ assertParGrep() {
     cat site/$1/index.html | \
         awk '/<div class="col-md-9" role="main">/,/<footer class="col-md-12">/' | \
         sed '1d; $d'  | head -n -3 > site/$1.grepout
-    # BANDAID: fix mkdocstrings id order for 3.6/3.7
-    sed -i 's/<h3 class="doc doc-heading" id="module.main">/<h3 id="module.main" class="doc doc-heading">/g' site/$1.grepout
     echo "--------------"
     echo "-_---File-----"
     echo `pwd`/site/$1/index.html


### PR DESCRIPTION
Versions are set in requirements.txt, making this bandaid not needed.