### PR TITLE
Add handling for .mkdocsignore to ignore files or folders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "markupsafe",
     "materialx",
     "mkdocs",
+    "mkdocsignore",
     "mkdocstrings",
     "mypy",
     "pycodestyle",

--- a/examples/.pages
+++ b/examples/.pages
@@ -14,3 +14,4 @@ nav:
     - Extract docs with macros: examples/ok-with-macros
     - Extract docs with mkdocstrings: examples/ok-with-mkdocstrings
     - Extract a snippet: examples/ok-source-with-snippet
+    - Ignore with .mkdocsignore: examples/ok-mkdocsignore

--- a/examples/gen_readme.py
+++ b/examples/gen_readme.py
@@ -95,7 +95,7 @@ class GenerateExampleReadme():
 
     def include_input(self, path):
         """The files to expand as input examples."""
-        include_list = ['.py', '.c', '.litcoffee', '.cpp']
+        include_list = ['.py', '.c', '.litcoffee', '.cpp', '.mkdocsignore']
         return any(extension in path.display_name for extension in include_list)
 
     def include_output(self, path):

--- a/examples/ok-mkdocsignore/.mkdocsignore
+++ b/examples/ok-mkdocsignore/.mkdocsignore
@@ -1,0 +1,4 @@
+# Ignore everything in the test folder
+test
+# Ignore the foo file in hello/foo
+hello/foo/foo*

--- a/examples/ok-mkdocsignore/hello/foo/bar.md
+++ b/examples/ok-mkdocsignore/hello/foo/bar.md
@@ -1,0 +1,3 @@
+# Bar
+
+This is for testing files in the hello/foo directory.

--- a/examples/ok-mkdocsignore/hello/foo/foo.md
+++ b/examples/ok-mkdocsignore/hello/foo/foo.md
@@ -1,0 +1,3 @@
+# Foo
+
+This is for testing files in the hello/foo directory.

--- a/examples/ok-mkdocsignore/hello/hello.md
+++ b/examples/ok-mkdocsignore/hello/hello.md
@@ -1,0 +1,3 @@
+# Test Hello
+
+This is a hello test.

--- a/examples/ok-mkdocsignore/hello/world/.mkdocsignore
+++ b/examples/ok-mkdocsignore/hello/world/.mkdocsignore
@@ -1,0 +1,1 @@
+# Ignore everything in this folder

--- a/examples/ok-mkdocsignore/hello/world/world.md
+++ b/examples/ok-mkdocsignore/hello/world/world.md
@@ -1,0 +1,3 @@
+# Test World
+
+This is a world test.

--- a/examples/ok-mkdocsignore/mkdocs-test.yml
+++ b/examples/ok-mkdocsignore/mkdocs-test.yml
@@ -1,0 +1,4 @@
+# Ignore files with a .mkdocsignore file.
+site_name: ok-mkdocsignore
+plugins:
+  - simple

--- a/examples/ok-mkdocsignore/test/bar.md
+++ b/examples/ok-mkdocsignore/test/bar.md
@@ -1,0 +1,3 @@
+# Bar
+
+This is for testing files in the test directory.

--- a/examples/ok-mkdocsignore/test/foo.md
+++ b/examples/ok-mkdocsignore/test/foo.md
@@ -1,0 +1,3 @@
+# Foo
+
+This is for testing files in the test directory.

--- a/tests/integration_test.bats
+++ b/tests/integration_test.bats
@@ -252,6 +252,18 @@ teardown() {
     assertFileNotExists site/hello_world/index.html
 }
 
+@test "mkdocsignore" {
+    cd ${fixturesDir}/ok-mkdocsignore
+    assertGen
+    assertValidSite
+    assertFileNotExists site/test/foo/index.html
+    assertFileNotExists site/test/bar/index.html
+    assertFileExists site/hello/hello/index.html
+    assertFileNotExists site/hello/world/world/index.html
+    assertFileExists site/hello/foo/bar/index.html
+    assertFileNotExists site/hello/foo/foo/index.html
+}
+
 @test "serve a mkdocs site" {
     cd ${fixturesDir}/ok-mkdocs-docs
     assertGen


### PR DESCRIPTION
Since the plugin has switched to processing everything by default, it needs a more robust and scalable way to ignore files.

This feature adds the concept of a `.mkdocsignore` file, which works similarly to a `.gitgnore` file.  Files to ignore are specified by glob pattern inside of a .mkdocsignore file for files in lower directories.

See https://athackst.github.io/mkdocs-simple-plugin/latest/examples/ok-mkdocsignore for example
