### PR TITLE
Change include to use glob pattern and iterate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
         "mypy",
         "pycodestyle",
         "pydocstyle",
+        "pyfakefs",
         "pygments",
         "pylint",
         "pymdownx",

--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -84,13 +84,13 @@ mkdocs serve
 
 """
 import fnmatch
+import glob
 import os
 import shutil
 import stat
 import sys
 import tempfile
 import yaml
-from genericpath import exists
 
 
 from mkdocs.plugins import BasePlugin
@@ -251,17 +251,8 @@ class SimplePlugin(BasePlugin):
 
     def __init__(self):
         """Set up internal variables."""
-        self.build_docs_dir = None
         self.orig_docs_dir = None
-        self.include_folders = None
-        self.ignore_folders = None
-        self.ignore_hidden = None
-        self.include_extensions = None
-        self.merge_docs_dir = None
-        self.semiliterate = None
-        self.ignore_paths = None
         self.paths = None
-        self.ignore_patterns = set()
 
     def on_config(self, config, **kwargs):
         """Update configuration to use a temporary build directory."""
@@ -278,47 +269,45 @@ class SimplePlugin(BasePlugin):
         # PY2 returns a byte string by default. The Unicode prefix ensures a
         # Unicode string is returned. And it makes MkDocs temp dirs easier to
         # identify.
-        self.build_docs_dir = self.config['build_docs_dir']
-        if not self.build_docs_dir:
-            self.build_docs_dir = tempfile.mkdtemp(
+        build_docs_dir = self.config['build_docs_dir']
+        if not build_docs_dir:
+            build_docs_dir = tempfile.mkdtemp(
                 prefix="mkdocs_simple_" +
                 os.path.basename(
                     os.path.dirname(
                         config.config_file_path)))
         utils.log.info(
             "mkdocs-simple-plugin: build_docs_dir: %s",
-            self.build_docs_dir)
+            build_docs_dir)
+        self.config['build_docs_dir'] = build_docs_dir
         # Clean out build folder on config
-        shutil.rmtree(self.build_docs_dir, ignore_errors=True)
-        os.makedirs(self.build_docs_dir, exist_ok=True)
+        shutil.rmtree(build_docs_dir, ignore_errors=True)
+        os.makedirs(build_docs_dir, exist_ok=True)
         # Save original docs directory location
         self.orig_docs_dir = config['docs_dir']
         # Update the docs_dir with our temporary one
-        config['docs_dir'] = self.build_docs_dir
-        self.include_folders = self.config['include_folders']
-        self.ignore_folders = self.config['ignore_folders']
-        self.ignore_hidden = self.config['ignore_hidden']
-        self.include_extensions = utils.markdown_extensions + \
+        config['docs_dir'] = build_docs_dir
+        # Add all markdown extensions to include list
+        self.config['include_extensions'] = utils.markdown_extensions + \
             self.config['include_extensions']
-        self.merge_docs_dir = self.config['merge_docs_dir']
-        self.semiliterate = []
-        for item in self.config['semiliterate']:
-            self.semiliterate.append(Semiliterate(**item))
 
         # Always ignore the output paths
-        self.ignore_paths = [self._get_config_site_dir(config.config_file_path),
-                             config['site_dir'],
-                             self.build_docs_dir]
+        self.config["ignore_paths"] = [
+            get_config_site_dir(config.config_file_path),
+            config['site_dir'],
+            self.config['build_docs_dir']]
         return config
 
     def on_pre_build(self, config, **kwargs):
         """Build documentation directory with files according to settings."""
-        # Copy contents of docs directory if merging
-        if self.merge_docs_dir and os.path.exists(self.orig_docs_dir):
-            self._copy_docs_directory(self.orig_docs_dir, self.build_docs_dir)
-            self.ignore_paths += [self.orig_docs_dir]
+        # Configure simple
+        simple = Simple(**self.config)
+
+        # Merge docs
+        if self.config["merge_docs_dir"]:
+            simple.merge_docs(self.orig_docs_dir)
         # Copy all of the valid doc files into build_docs_dir
-        self.paths = self._build_docs()
+        self.paths = simple.build_docs()
 
     def on_serve(self, server, config, **kwargs):
         """Add files to watch server."""
@@ -332,10 +321,36 @@ class SimplePlugin(BasePlugin):
 
         return server
 
-    def _is_hidden(self, filepath):
-        """Return true if filepath is hidden."""
-        name = os.path.basename(os.path.abspath(filepath))
 
+class Simple():
+    """Mkdocs Simple Plugin"""
+
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+            self,
+            build_docs_dir: str,
+            include_folders: list,
+            include_extensions: list,
+            ignore_folders: list,
+            ignore_hidden: bool,
+            ignore_paths: list,
+            semiliterate: dict,
+            **kwargs):
+        """Initialize module instance with settings."""
+        self.build_dir = build_docs_dir
+        self.include_folders = set(include_folders)
+        self.include_extensions = set(include_extensions)
+        self.ignore_folders = set(ignore_folders)
+        self.ignore_hidden = ignore_hidden
+        self.hidden_prefix = set([".", "__"])
+        self.ignore_paths = set(ignore_paths)
+        self.semiliterate = []
+        for item in semiliterate:
+            self.semiliterate.append(Semiliterate(**item))
+
+    def is_hidden(self, filepath):
+        """Return true if filepath is hidden."""
         def has_hidden_attribute(filepath):
             """Returns true if hidden attribute is set."""
             try:
@@ -344,26 +359,31 @@ class SimplePlugin(BasePlugin):
             except (AttributeError, AssertionError):
                 return False
 
-        return name.startswith('.') or \
-            has_hidden_attribute(filepath) or \
-            name == "__pycache__"
+        def has_hidden_prefix(filepath):
+            name = os.path.basename(os.path.abspath(filepath))
+            return any(name.startswith(pattern)
+                       for pattern in self.hidden_prefix)
 
-    def _in_search_directory(self, directory: str, root: str) -> bool:
-        """Check if directory should be searched."""
-        path = os.path.join(root, directory)
+        return has_hidden_prefix(filepath) or has_hidden_attribute(filepath)
+
+    def is_ignored(self, base_path: str, name: str) -> bool:
+        """Check if directory and filename should be ignored."""
+        return self.is_path_ignored(os.path.join(base_path, name))
+
+    def is_path_ignored(self, path: str = None) -> bool:
+        """Check if path should be ignored."""
+        path = os.path.normpath(path)
+        base_path = os.path.dirname(path)
         # Check if it's hidden
-        if self.ignore_hidden and self._is_hidden(path):
-            return False
+        if self.ignore_hidden and self.is_hidden(path):
+            return True
         # Check if its an internally required ignore path
         if os.path.abspath(path) in self.ignore_paths:
-            return False
-        # Check for user defined paths in config
-        if any(fnmatch.fnmatch(path[2:], filter)
-               for filter in self.ignore_folders):
-            return False
+            return True
+
         # Update ignore patterns from .mkdocsignore file
-        mkdocsignore = os.path.join(root, ".mkdocsignore")
-        if exists(mkdocsignore):
+        mkdocsignore = os.path.join(base_path, ".mkdocsignore")
+        if os.path.exists(mkdocsignore):
             ignore_list = []
             with open(mkdocsignore, "r") as txt_file:
                 ignore_list = txt_file.read().splitlines()
@@ -371,118 +391,140 @@ class SimplePlugin(BasePlugin):
                 ignore_list = [x for x in ignore_list if not x.startswith('#')]
             if not ignore_list:
                 ignore_list = ["*"]
-            self.ignore_patterns.update(set(os.path.join(root, filter)
-                                            for filter in ignore_list))
+            self.ignore_folders.update(
+                set(os.path.join(base_path, filter) for filter in ignore_list))
         # Check for ignore paths in patterns
-        if any(fnmatch.fnmatch(path, filter)
-                for filter in self.ignore_patterns):
-            return False
-        return True
+        if any(fnmatch.fnmatch(os.path.normpath(path), filter)
+                for filter in self.ignore_folders):
+            return True
+        return False
 
-    def _in_include_directory(self, directory: str) -> bool:
-        """Check if directory in include list."""
-        return any(fnmatch.fnmatch(directory, filter)
-                   for filter in self.include_folders)
+    def get_included(self) -> list:
+        """Get a list of folders and files to include."""
+        included = []
+        for pattern in self.include_folders:
+            included.extend(glob.glob(pattern))
+        # Return filtered list of included files
+        return [f for f in included if not self.is_path_ignored(f)]
 
-    def _in_extensions(self, file: str) -> bool:
+    def in_extensions(self, name: str) -> bool:
         """Check if file is in include extensions."""
-        return any(extension in file for extension in self.include_extensions)
+        return any(extension in name for extension in self.include_extensions)
 
-    def _get_config_site_dir(self, config_file_path: str) -> str:
-        """Get configuration directory from mkdocs.yml file.
+    def merge_docs(self, from_dir):
+        """Merge docs directory"""
+        # Copy contents of docs directory if merging
+        if os.path.exists(from_dir):
+            copy_directory(from_dir, self.build_dir)
+            self.ignore_paths.add(from_dir)
 
-        This is needed in the case you are running mkdocs serve, which
-        overwrites the path with a temporary one.
-        """
-        orig_config = mkdocs_config.load_config(config_file_path)
-        utils.log.debug(
-            "mkdocs-simple-plugin: loading file: %s", config_file_path)
-
-        utils.log.debug(
-            "mkdocs-simple-plugin: User config site_dir: %s",
-            orig_config.data['site_dir'])
-        return orig_config.data['site_dir']
-
-    def _build_docs(self) -> list:
+    def build_docs(self) -> list:
         """Build the docs directory from workspace files."""
         paths = []
-        for root, directories, files in os.walk("."):
-            if self._in_include_directory(root):
-                document_root = self.build_docs_dir + root[1:]
+        included = self.get_included()
+        for item in included:
+            paths += filter(None, [self._process(item)])
+            for root, directories, files in os.walk(item):
                 for file in files:
-                    if not self._in_search_directory(file, root):
-                        continue
-                    copied = self._copy_file(root, file, document_root)
-                    extracted = self._extract_from(root, file, document_root)
-                    if copied or extracted:
-                        paths.append(os.path.join(root, file))
-            directories[:] = [d for d in directories
-                              if self._in_search_directory(d, root)]
+                    path = os.path.join(root, file)
+                    paths += filter(None, [self._process(path)])
+                directories[:] = [
+                    d for d in directories if not self.is_ignored(root, d)]
         return paths
 
-    def _copy_file(
-            self,
-            from_directory: str,
-            name: str,
-            destination_directory: str) -> bool:
+    def _process(self, file) -> str:
+        if not os.path.isfile(file):
+            return None
+        from_dir = os.path.dirname(file)
+        name = os.path.basename(file)
+        build_prefix = os.path.normpath(os.path.join(self.build_dir, from_dir))
+
+        if (self.try_copy_file(from_dir, name, build_prefix) or
+                self.try_extract(from_dir, name, build_prefix)):
+            return file
+        return None
+
+    def try_copy_file(self, from_dir: str, name: str, to_dir: str) -> bool:
         """Copy file with the same name to a new directory.
 
         Returns true if file copied.
         """
-        original = os.path.join(from_directory, name)
-        if self._in_extensions(name):
-            new_file = os.path.join(destination_directory, name)
-            try:
-                os.makedirs(destination_directory, exist_ok=True)
-                shutil.copy(original, new_file)
-                utils.log.debug("mkdocs-simple-plugin: %s --> %s",
-                                original, new_file)
-                return True
-            except (OSError, IOError, UnicodeDecodeError) as error:
-                utils.log.warning(
-                    "mkdocs-simple-plugin: error! %s.. skipping %s",
-                    error, original)
+        original = os.path.join(from_dir, name)
+        new_file = os.path.join(to_dir, name)
+
+        if not self.in_extensions(name):
+            utils.log.info(
+                "mkdocs-simple-plugin: skipping file extension %s", original)
+            return False
+        if self.is_path_ignored(original):
+            utils.log.debug(
+                "mkdocs-simple-plugin: ignoring %s", original)
+            return False
+        try:
+            os.makedirs(to_dir, exist_ok=True)
+            shutil.copy(original, new_file)
+            utils.log.debug("mkdocs-simple-plugin: %s --> %s",
+                            original, new_file)
+            return True
+        except (OSError, IOError, UnicodeDecodeError) as error:
+            utils.log.warning(
+                "mkdocs-simple-plugin: %s.. skipping %s",
+                error, original)
         return False
 
-    def _extract_from(self, from_directory: str, name: str,
-                      destination_directory: str) -> bool:
+    def try_extract(self, from_dir: str, name: str, to_dir: str) -> bool:
         """Extract content from file into destination.
 
         Returns the name of the file extracted if extractable.
         """
+        path = os.path.join(from_dir, name)
+        if self.is_path_ignored(path):
+            utils.log.debug(
+                "mkdocs-simple-plugin: ignoring %s", path)
+            return False
         extracted = False
         for item in self.semiliterate:
-            if not self._in_extensions(name):
-                if item.try_extraction(
-                        from_directory, name, destination_directory):
-                    extracted = True
+            if item.try_extraction(from_dir, name, to_dir):
+                extracted = True
 
         return extracted
 
-    def _copy_docs_directory(
-            self,
-            root_source_directory: str,
-            root_destination_directory: str):
-        """Copy all files from source to destination directory."""
-        if sys.version_info >= (3, 8):
-            # pylint: disable=unexpected-keyword-arg
-            shutil.copytree(root_source_directory,
-                            root_destination_directory,
-                            dirs_exist_ok=True)
-            utils.log.debug("mkdocs-simple-plugin: %s/* --> %s/*",
-                            root_source_directory, root_destination_directory)
-        else:
-            for source_directory, _, files in os.walk(root_source_directory):
-                destination_directory = source_directory.replace(
-                    root_source_directory, root_destination_directory, 1)
-                os.makedirs(destination_directory, exist_ok=True)
-                for file_ in files:
-                    source_file = os.path.join(source_directory, file_)
-                    destination_file = os.path.join(destination_directory,
-                                                    file_)
-                    if os.path.exists(destination_file):
-                        os.remove(destination_file)
-                    shutil.copy(source_file, destination_directory)
-                    utils.log.debug(
-                        "mkdocs-simple-plugin: %s/* --> %s/*",
-                        source_file, destination_file)
+
+def get_config_site_dir(config_file_path: str) -> str:
+    """Get configuration directory from mkdocs.yml file.
+
+    This is needed in the case you are running mkdocs serve, which
+    overwrites the path with a temporary one.
+    """
+    orig_config = mkdocs_config.load_config(config_file_path)
+    utils.log.debug(
+        "mkdocs-simple-plugin: loading file: %s", config_file_path)
+
+    utils.log.debug(
+        "mkdocs-simple-plugin: User config site_dir: %s",
+        orig_config.data['site_dir'])
+    return orig_config.data['site_dir']
+
+
+def copy_directory(from_dir: str, to_dir: str):
+    """Copy all files from source to destination directory."""
+    if sys.version_info >= (3, 8):
+        # pylint: disable=unexpected-keyword-arg
+        shutil.copytree(from_dir, to_dir, dirs_exist_ok=True)
+        utils.log.debug("mkdocs-simple-plugin: %s/* --> %s/*",
+                        from_dir, to_dir)
+    else:
+        for source_directory, _, files in os.walk(from_dir):
+            destination_directory = source_directory.replace(
+                from_dir, to_dir, 1)
+            os.makedirs(destination_directory, exist_ok=True)
+            for file_ in files:
+                source_file = os.path.join(source_directory, file_)
+                destination_file = os.path.join(destination_directory,
+                                                file_)
+                if os.path.exists(destination_file):
+                    os.remove(destination_file)
+                shutil.copy(source_file, destination_directory)
+                utils.log.debug(
+                    "mkdocs-simple-plugin: %s/* --> %s/*",
+                    source_file, destination_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ mkdocstrings==0.19.0
 mkdocstrings-python-legacy==0.2.3
 pip-upgrader==1.4.15
 pydocstyle==6.1.1
+pyfakefs==4.6.3
 pymdown-extensions==9.5
 PyYAML==6.0

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 pip install -e .
+pip install pyfakefs
 # md file="test.snippet" content="^#?\s?(.*)"
 # ### Unit tests
 #

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+"""Test mkdocs_simple_plugin.simple"""
+import unittest
+from unittest.mock import patch
+import stat
+import os
+from pyfakefs.fake_filesystem_unittest import TestCase
+
+from mkdocs_simple_plugin import plugin as simple
+
+
+class TestSimpleHelpers(TestCase):
+    """Test Simple helper functions."""
+
+    def setUp(self):
+        """Set up with fake filesystem"""
+        self.setUpPyfakefs()
+
+    def test_copy_directory(self):
+        """Test copy_directory"""
+        self.fs.create_file('/test/file.txt')
+        simple.copy_directory("/test", '/bar')
+        self.assertTrue(os.path.exists("/bar/file.txt"))
+
+
+class TestSimple(TestCase):
+    """Test Simple class."""
+
+    def setUp(self) -> None:
+        """Set defaults"""
+        self.default_settings = {
+            "build_docs_dir": "/build_dir/",
+            "include_folders": ["*"],
+            "ignore_folders": [],
+            "ignore_hidden": True,
+            "include_extensions": [".md"],
+            "ignore_paths": [],
+            "semiliterate": {}
+        }
+        self.setUpPyfakefs()
+
+    @patch("os.stat")
+    def test_is_hidden(self, os_stat):
+        """Test is_hidden for correctness."""
+        simple_test = simple.Simple(**self.default_settings)
+        os_stat.return_value.st_file_attributes = 0
+        self.assertFalse(simple_test.is_hidden('test.md'))
+        self.assertFalse(simple_test.is_hidden('./folder/test.md'))
+        self.assertTrue(simple_test.is_hidden('__pycache__'))
+        self.assertTrue(simple_test.is_hidden('.mkdocsignore'))
+        # Check hidden file attribute
+        os_stat.return_value.st_file_attributes = stat.FILE_ATTRIBUTE_HIDDEN
+        self.assertTrue(simple_test.is_hidden('/test/file'))
+
+    def test_ignored_default(self):
+        """Test ignored files."""
+        simple_test = simple.Simple(**self.default_settings)
+        self.fs.create_file("directory/file")
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path="directory",
+                name="file"
+            )
+        )
+
+    def test_ignored_hidden(self):
+        """Test ignored files."""
+        simple_test = simple.Simple(**self.default_settings)
+
+        self.fs.create_file("directory/.hidden")
+        simple_test.ignore_hidden = True
+        self.assertTrue(
+            simple_test.is_ignored(
+                base_path="directory",
+                name=".hidden"
+            )
+        )
+        simple_test.ignore_hidden = False
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path="directory",
+                name=".hidden"
+            )
+        )
+
+        self.fs.create_file("directory/file")
+        simple_test.ignore_hidden = True
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path="directory",
+                name="file"
+            )
+        )
+        simple_test.ignore_hidden = False
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path="directory",
+                name="file"
+            )
+        )
+
+    def test_ignored_paths(self):
+        """Test ignored files."""
+        simple_test = simple.Simple(**self.default_settings)
+        base_path = "directory"
+        name = "test.md"
+        path = os.path.join(base_path, name)
+        self.fs.create_file(path)
+
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path=base_path,
+                name=name))
+
+        abs_path = os.path.abspath(os.path.join(base_path, name))
+        simple_test.ignore_paths = [abs_path]
+        self.assertTrue(simple_test.is_ignored(base_path=base_path, name=name))
+
+    def test_ignored_config(self):
+        """Test ignored files from config."""
+        self.default_settings["ignore_folders"] = ["test/*"]
+        simple_test = simple.Simple(**self.default_settings)
+        self.fs.create_file("directory/test.md")
+        self.assertFalse(
+            simple_test.is_ignored(base_path="directory", name="test.md"))
+        self.fs.create_file("test/file.md")
+        self.assertTrue(
+            simple_test.is_ignored(base_path="test", name="file.md"))
+
+    def test_ignored_mkdocsignore(self):
+        """Test mkdocsignore file."""
+        simple_test = simple.Simple(**self.default_settings)
+
+        self.fs.create_file("directory/.mkdocsignore", contents="*test*")
+        self.fs.create_file("directory/test.md")
+        self.assertTrue(
+            simple_test.is_ignored(
+                base_path="directory",
+                name="test.md"))
+        self.fs.create_file("./directory/hello.md")
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path="directory",
+                name="hello.md"))
+
+        self.fs.create_file(".mkdocsignore", contents="*test*")
+        self.fs.create_file("test.md")
+        self.assertTrue(
+            simple_test.is_ignored(
+                base_path=".",
+                name="test.md"))
+        self.fs.create_file("hello.md")
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path=".",
+                name="hello.md"))
+        self.assertIn("directory/*test*", simple_test.ignore_folders)
+        self.assertIn("*test*", simple_test.ignore_folders)
+        self.assertEqual(2, len(simple_test.ignore_folders))
+
+    def test_ignored_mkdocsignore_empty(self):
+        """Test empty mkdocsignore file."""
+        simple_test = simple.Simple(**self.default_settings)
+        self.fs.create_file("./directory/.mkdocsignore")
+        self.fs.create_file("./directory/test.md")
+        self.assertTrue(
+            simple_test.is_ignored(
+                base_path="./directory",
+                name="test.md"))
+        self.fs.create_file("hello.md")
+        self.assertFalse(
+            simple_test.is_ignored(
+                base_path=".",
+                name="hello.md"))
+        self.assertIn("directory/*", simple_test.ignore_folders)
+        self.assertEqual(1, len(simple_test.ignore_folders))
+
+    def test_in_extensions(self):
+        """Test extensions to search."""
+        self.default_settings["include_extensions"] = [".md"]
+        simple_test = simple.Simple(**self.default_settings)
+        self.assertTrue(simple_test.in_extensions(name="helloworld.md"))
+        self.assertFalse(simple_test.in_extensions(name="md.helloworld"))
+
+    def test_build_docs(self):
+        """Test build docs."""
+        simple_test = simple.Simple(**self.default_settings)
+
+        # /foo
+        #  ├── baz.md
+        #  ├── .mkdocsignore //hidden + ignore settings
+        #  └── bar
+        #      ├── .hidden  // hidden file
+        #      ├── spam.md // ignored
+        #      ├── hello.txt  // wrong extension
+        #      └── eggs.md
+        #  └── bat // ignore directory
+        #      ├── hello.md
+        #      └── world.md
+        # /goo // not included
+        #  └── day.md
+        # boo.md // not included
+        self.fs.create_file("/foo/baz.md")
+        self.fs.create_file("/foo/.mkdocsignore", contents="bar/spam.md*")
+        self.fs.create_file("/foo/bar/spam.md")
+        self.fs.create_file("/foo/bar/eggs.md")
+        self.fs.create_file("/foo/bar/.hidden")
+        self.fs.create_file("/foo/bat/hello.md")
+        self.fs.create_file("/foo/bat/world.md")
+        self.fs.create_file("/goo/day.md")
+        self.fs.create_file("boo.md")
+
+        simple_test.ignore_folders = set(["foo/bat/**"])
+        simple_test.include_folders = set(["foo/*"])
+
+        paths = simple_test.build_docs()
+        self.assertIn("foo/baz.md", paths)
+        self.assertIn("foo/bar/eggs.md", paths)
+        self.assertEqual(2, len(paths))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change more faithfully represents the documented behavior.

Before, include folders needed `./` prefixed to match the prefix in `os.walk`.

Now, normal glob patterns work as expected.