### PR TITLE
test: Extend the custom extraction test

### DIFF
--- a/examples/ok-mkdocs-custom-extract/drone.yml
+++ b/examples/ok-mkdocs-custom-extract/drone.yml
@@ -1,0 +1,32 @@
+---
+### develop
+# ## Developing
+#
+# You can clone the repository with
+# ```
+# git clone https://this_is_a_dummy_url
+# ```
+###
+kind: pipeline
+name: bootstrap
+steps:
+  - name: fetch tags
+    image: alpine/git
+    commands:
+    - git fetch --tags
+
+  - name: build_install_test
+    image: python
+    commands:
+      - python --version
+      - pwd
+      - pip install flake8
+### develop
+# You can build the distribution with
+# ```
+      - pip install build
+      - python -m build .
+# ```
+# That will produce a `.whl` file in the `dist` subdirectory.
+###
+      - flake8 --max-line-length=80 --extend-exclude=build

--- a/examples/ok-mkdocs-custom-extract/drone_develop.grepout
+++ b/examples/ok-mkdocs-custom-extract/drone_develop.grepout
@@ -1,0 +1,10 @@
+<h2 id="developing">Developing</h2>
+<h1 id="_1"></h1>
+<p>You can clone the repository with</p>
+<pre><code>git clone https://this_is_a_dummy_url
+</code></pre>
+<p>You can build the distribution with</p>
+<pre><code> pip install build
+ python -m build .
+</code></pre>
+<p>That will produce a <code>.whl</code> file in the <code>dist</code> subdirectory.</p></div>

--- a/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
+++ b/examples/ok-mkdocs-custom-extract/mkdocs-test.yml
@@ -4,6 +4,12 @@
 # everything from the beginning of the file to the first line of code
 # (a line indented by at least four spaces), together with any later Markdown
 # block preceded by a comment containing `# DOCPAGE`.
+#
+# Similarly, you may want to have to have a custom extraction even for a
+# standard file pattern, or for one particular file; the `drone.yml` pattern
+# could for example extract development documentation from a Drone yml file.
+# Note this latter pattern takes advantage of the fact that you can have just
+# a single top-level block of parameters in an `extract:` section.
 site_name: ok-mkdocs-custom-extract
 plugins:
   - simple:
@@ -12,3 +18,9 @@ plugins:
           extract:
             - {stop: '^\s{4,}\S'}  # No start, so active from beginning
             - {start: '# DOCPAGE', stop: '^\s{4,}\S'}
+        - pattern: 'drone.yml'
+          destination: 'drone_develop.md'
+          extract:
+            start: '### develop'
+            stop: '^\s*###'
+            replace: ['^# (.*\s*)$', '^\s*-(.*\s*)$']

--- a/tests/integration_test.bats
+++ b/tests/integration_test.bats
@@ -176,6 +176,8 @@ teardown() {
     assertValidSite
     assertFileExists site/fibo/index.html
     assertParGrep fibo
+    assertFileExists site/drone_develop/index.html
+    assertParGrep drone_develop
 }
 
 @test "ignore site directory" {
@@ -237,7 +239,7 @@ teardown() {
     assertParGrep module
 }
 
-@test "build a site with iniline settings" {
+@test "build a site with inline settings" {
     cd ${fixturesDir}/ok-mkdocs-inline-settings
     assertGen
     assertValidSite


### PR DESCRIPTION
  Adds a portion of mkdocs-test.yml from the source of mkdocs-semiliterate,
  in an effort to help ensure that future revisions of mkdocs-simple-plugin
  will support the features used in the mkdocs-semiliterate derivative
  of this plugin.

  As suggested in #403.