### PR TITLE
Switch to pyproject.toml and Hatch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,14 @@ jobs:
           cache: 'pip'
       - name: Build and Publish
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          HATCH_INDEX_USER: ${{ secrets.PYPI_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install -U hatch
           pip install -r requirements.txt;
-          python setup.py sdist bdist_wheel
-          twine upload dist/* --verbose
+          hatch build
+          hatch publish 
   release-docker:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mkdocs-simple-plugin"
+dynamic = ["version"]
+description = "Plugin for adding simple wiki site creation from markdown files interspersed within your code with MkDocs."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3"
+authors = [
+    { name = "Allison Thackston", email = "allison@allisonthackston.com" },
+]
+keywords = [
+    "mkdocs",
+    "readme",
+    "wiki",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+# md file="versions.snippet"
+# _Python 3.x, 3.7, 3.8, 3.9, 3.10 supported._
+# /md
+dependencies = [
+    "click>=7.1",
+    "MarkupSafe>=2.1.1",
+    "mkdocs>=1.4.0",
+    "PyYAML>=6.0",
+]
+
+[project.scripts]
+mkdocs_simple_gen = "mkdocs_simple_plugin.generator:main"
+
+[project.entry-points."mkdocs.plugins"]
+simple = "mkdocs_simple_plugin.plugin:SimplePlugin"
+
+[project.urls]
+Documentation = "http://althack.dev/mkdocs-simple-plugin"
+Homepage = "http://althack.dev/mkdocs-simple-plugin"
+Issues = "https://github.com/athackst/mkdocs-simple-plugin/issues"
+"Source Code" = "https://github.com/athackst/mkdocs-simple-plugin"
+
+[tool.hatch.version]
+path = "VERSION"
+pattern = "(?P<version>.+)"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/mkdocs_simple_plugin",
+]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,4 @@ setuptools.setup(
         'mkdocs.plugins': ["simple = mkdocs_simple_plugin.plugin:SimplePlugin"],
         'console_scripts': ["mkdocs_simple_gen = mkdocs_simple_plugin.generator:main"]})
 
-# md file="versions.snippet"
-# _Python 3.x, 3.7, 3.8, 3.9, 3.10 supported._
-# /md
+


### PR DESCRIPTION
Converting to new standard for python package metadata [pyproject.toml](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/)

Using [Hatch](https://hatch.pypa.io/latest/) to match [mkdocs packaging](https://github.com/mkdocs/mkdocs/pull/2988)

Generated with

```bash
hatch new --init
```