### PR TITLE
First pass at incremental dirtyreload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 dist/
 .vscode/.ropeproject/
 .cache
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,23 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN \
+  apk add --no-cache \
+  git \
+  git-fast-import \
+  git-lfs \
+  openssh \
+  cairo-dev \
+  freetype-dev \
+  libffi-dev \
+  jpeg-dev \
+  libpng-dev \
+  zlib-dev \
+  && apk add --no-cache --virtual .build gcc musl-dev \
+  && apk add --no-cache --upgrade bash \
+  && pip install --upgrade pip \
+  && pip install --no-cache-dir mkdocs-material mike pillow cairosvg
+
 WORKDIR /tmp
 COPY mkdocs_simple_plugin mkdocs_simple_plugin
 COPY README.md README.md
@@ -11,23 +28,7 @@ COPY VERSION VERSION
 COPY setup.py setup.py
 COPY pyproject.toml pyproject.toml
 
-RUN \
-  apk add --no-cache \
-    git \
-    git-fast-import \
-    git-lfs \
-    openssh \
-    cairo-dev \
-    freetype-dev \
-    libffi-dev \
-    jpeg-dev \
-    libpng-dev \
-    zlib-dev \
-  && apk add --no-cache --virtual .build gcc musl-dev \
-  && apk add --no-cache --upgrade bash \
-  && pip install --upgrade pip \
-  && pip install --no-cache-dir mkdocs-material mike pillow cairosvg \
-  && pip install --no-cache-dir . \
+RUN pip install --no-cache-dir . \
   && rm -rf /tmp/*
 
 WORKDIR /docs
@@ -42,4 +43,4 @@ COPY docker/deploy.sh /usr/local/bin/
 COPY docker/entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["entrypoint.sh"]
 
-CMD ["mkdocs_simple_gen", "--serve", "--", "-a", "0.0.0.0:8000"]
+CMD ["mkdocs_simple_gen", "--serve", "--", "-a", "0.0.0.0:8000", "--dirtyreload"]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Test](https://github.com/athackst/mkdocs-simple-plugin/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/athackst/mkdocs-simple-plugin/actions/workflows/test.yml)
 [![Docs](https://github.com/athackst/mkdocs-simple-plugin/actions/workflows/publish_docs.yml/badge.svg?branch=main)](https://github.com/athackst/mkdocs-simple-plugin/actions/workflows/publish_docs.yml)
-[![Docker](https://img.shields.io/docker/pulls/althack/mkdocs-simple-plugin)](https://hub.docker.com/r/althack/mkdocs-simple-plugin) 
-[![pypi](https://img.shields.io/pypi/dm/mkdocs-simple-plugin?label=pypi%20downloads&color=blue)](https://pypi.org/project/mkdocs-simple-plugin/) 
+[![Docker](https://img.shields.io/docker/pulls/althack/mkdocs-simple-plugin)](https://hub.docker.com/r/althack/mkdocs-simple-plugin)
+[![pypi](https://img.shields.io/pypi/dm/mkdocs-simple-plugin?label=pypi%20downloads&color=blue)](https://pypi.org/project/mkdocs-simple-plugin/)
 [![Github Action](https://img.shields.io/badge/github%20action-download-blue)](https://github.com/marketplace/actions/mkdocs-simple-action)
 
 # mkdocs-simple-plugin
@@ -16,7 +16,7 @@ You may be wondering why you would want to generate a static site for your proje
 
 * **My repository is too big for a single documentation source.**
 
-    Sometimes it isn't feasible to consolidate all documentation within an upper level `docs` directory.  In general, if your codebase is too large to fit well within a single `include` directory, your codebase is also too large for documentation in a single `docs` directory.  
+    Sometimes it isn't feasible to consolidate all documentation within an upper level `docs` directory.  In general, if your codebase is too large to fit well within a single `include` directory, your codebase is also too large for documentation in a single `docs` directory.
 
     Since it's typically easier to keep documentation up to date when it lives as close to the code as possible, it is better to create multiple sources for documentation.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: athackst/mkdocs-simple-plugin
 docs_dir: /tmp/mkdocs-simple/mkdocs-simple-plugin
 plugins:
-  - simple
+  - simple:
+      build_docs_dir: build/docs
+      ignore_folders:
+        - venv/*
   - awesome-pages
   - macros
   - search


### PR DESCRIPTION
Rough sketch of how we may approach supporting incremental dirty reload. Currently, this enables incremental mode only if two conditions are met:

1. The server is being run with --dirtyreload enabled
2. build_docs_dir was supplied by the user

The second condition exists because I _think_ it's required for something like this to work; without it, mkdocs won't have access to the generated build files (I think). Incremental mode also disables merging beyond the first run right now, but I'm not 100% sure if that's correct either.