### PR TITLE
Don't watch the build docs dir

### DIFF
--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -329,7 +329,8 @@ class SimplePlugin(BasePlugin):
         # watch the original docs/ directory
         if os.path.exists(self.orig_docs_dir):
             server.watch(self.orig_docs_dir)
-        server.watch(self.config["build_docs_dir"])
+        # don't watch the build directory
+        server.unwatch(self.config["build_docs_dir"])
 
         # watch all the doc files
         for path in self.paths:


### PR DESCRIPTION
Closes #483 

Before 40415a3d913134b5e47312f780a3353364b7fded the plugin was creating a new temporary directory on every reload so built artifacts weren't marked as changed.  After the update, the same temporary directory is used.  This caused built artifacts to trigger a file change event.

This fix unwatches the build docs dir so those changes don't fire rebuild events.  Now only file changes in the source directory should trigger rebuilds as expected.