### PR TITLE
Add `generated_by` parameter to newly created Files

### DIFF
--- a/mkdocs_simple_plugin/plugin.py
+++ b/mkdocs_simple_plugin/plugin.py
@@ -390,7 +390,8 @@ class SimplePlugin(BasePlugin):
                 src_dir=os.path.abspath(path.output_root),
                 path=path.output_relpath,
                 dest_dir=config.site_dir,
-                use_directory_urls=config["use_directory_urls"]
+                use_directory_urls=config["use_directory_urls"],
+                generated_by="mkdocs_simple_plugin",
             )
             if file.src_uri in files.src_uris:
                 files.remove(file)


### PR DESCRIPTION
See https://github.com/mkdocs/mkdocs/blob/4c7404485f988f409ccaf42fefe705222ff5965a/mkdocs/structure/files.py#L238C5-L238C17

This help with compatibility with other plugins that use `git` information